### PR TITLE
feat: add CodeCov step

### DIFF
--- a/.github/workflows/ruby-test-matrix.yml
+++ b/.github/workflows/ruby-test-matrix.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: "bundle exec rspec"
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+        description: Optional Codecov upload token for coverage reports
 
 jobs:
   gemfile-paths:
@@ -58,6 +62,7 @@ jobs:
         command: ${{ inputs.test-command }}
     - name: Upload coverage reports to Codecov
       continue-on-error: true
+      if: ${{ hashFiles('coverage/lcov.info') != '' }}
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ruby-test-matrix.yml
+++ b/.github/workflows/ruby-test-matrix.yml
@@ -56,6 +56,12 @@ jobs:
         max_attempts: 2
         timeout_minutes: 10
         command: ${{ inputs.test-command }}
+    - name: Upload coverage reports to Codecov
+      continue-on-error: true
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage/lcov.info
 
   build_success:
     if: always()


### PR DESCRIPTION
## What

Adds a Codecov upload step to the reusable Ruby test matrix workflow. After the test command runs in each matrix cell (ruby version × gemfile), the step uploads `coverage/lcov.info` to Codecov via `codecov/codecov-action@v5`.

Every repo consuming this workflow gets Codecov coverage reporting automatically on its next run — no per-repo workflow changes needed.

## Why

Part of the org-wide Codecov rollout (see "Standardizing Code Coverage Tooling with CodeCov"). Centralizing the upload in this shared workflow gives all gem repos coverage reporting and PR comments without copy-pasting config into each one, and removes the need for callers to run a separate coverage job (which duplicated the test run).

## Notes for consuming repos

- **Safe by default**: the step has `continue-on-error: true`, so repos that don't yet produce coverage output (or a flaky upload) will never fail the build.
- **Token**: the step reads `secrets.CODECOV_TOKEN`. This is set as an org-level Actions secret, but reusable workflows don't inherit caller secrets automatically — callers must invoke the workflow with `secrets: inherit` (or pass `CODECOV_TOKEN` explicitly).
- **Coverage output**: repos need SimpleCov configured with an lcov formatter writing to `coverage/lcov.info` for the upload to have data.
- Each matrix cell uploads separately; Codecov merges uploads for the same commit into one report.
