### PR TITLE
fix: add 'Upload test results to Codecov'

### DIFF
--- a/.github/workflows/ruby-test-matrix.yml
+++ b/.github/workflows/ruby-test-matrix.yml
@@ -67,6 +67,11 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage/lcov.info
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   build_success:
     if: always()

--- a/.github/workflows/ruby-test-matrix.yml
+++ b/.github/workflows/ruby-test-matrix.yml
@@ -67,11 +67,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage/lcov.info
-    - name: Upload test results to Codecov
-      if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        report_type: test_results
 
   build_success:
     if: always()


### PR DESCRIPTION
## Context

The org-wide Codecov rollout added coverage uploads in [PR #3](https://github.com/Invoca/ruby-test-matrix-workflow/pull/3) but omitted the `codecov/test-results-action` step required to publish JUnit test results to Codecov alongside coverage data. This PR adds that missing step.

## Overview

Adds a Codecov test results upload step to the CI workflow so test run data (not just coverage) is reported to Codecov, running even when earlier steps are cancelled.